### PR TITLE
Fix controller panic caused by uninitialized NodeStatsProvider

### DIFF
--- a/controllers/devbox/cmd/main.go
+++ b/controllers/devbox/cmd/main.go
@@ -52,6 +52,7 @@ import (
 	"github.com/labring/sealos/controllers/devbox/internal/controller/utils/matcher"
 	"github.com/labring/sealos/controllers/devbox/internal/controller/utils/nodes"
 	utilresource "github.com/labring/sealos/controllers/devbox/internal/controller/utils/resource"
+	"github.com/labring/sealos/controllers/devbox/internal/stat"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -271,6 +272,7 @@ func main() {
 		RestartPredicateDuration: restartPredicateDuration,
 		NodeName:                 nodes.GetNodeName(),
 		AcceptanceThreshold:      acceptanceThreshold,
+		NodeStatsProvider:        &stat.NodeStatsProviderImpl{},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Devbox")
 		os.Exit(1)

--- a/controllers/devbox/internal/controller/devbox_controller.go
+++ b/controllers/devbox/internal/controller/devbox_controller.go
@@ -645,9 +645,15 @@ func (r *DevboxReconciler) getAcceptanceScore(ctx context.Context) int {
 		goto unsuitable // If we can't get the acceptance consideration, we assume the node is not suitable
 	}
 	containerFsStats, err = r.ContainerFsStats(ctx)
-	if err != nil || containerFsStats.AvailableBytes == nil || containerFsStats.CapacityBytes == nil {
+	if err != nil {
 		logger.Error(err, "failed to get container filesystem stats")
 		goto unsuitable // If we can't get the container filesystem stats, we assume the node is not suitable
+	} else if containerFsStats.AvailableBytes == nil {
+		logger.Info("available bytes is nil, assume the node is not suitable")
+		goto unsuitable // If we can't get the available bytes, we assume the node is not suitable
+	} else if containerFsStats.CapacityBytes == nil {
+		logger.Info("capacity bytes is nil, assume the node is not suitable")
+		goto unsuitable // If we can't get the capacity bytes, we assume the node is not suitable
 	}
 	availableBytes = *containerFsStats.AvailableBytes
 	capacityBytes = *containerFsStats.CapacityBytes


### PR DESCRIPTION
Add NodeStatsProvider to Devbox controller and enhance error handling  for container filesystem stats
<!-- 
If you are developing a feature, please provide documentation.
If you are solving a bug, please associate the corresponding issue.
Please standardize the title and introduction information of the PR, 
because it will be placed in the release note.
-->
